### PR TITLE
Sample a uniformly random point in the annulus

### DIFF
--- a/poissondisc.go
+++ b/poissondisc.go
@@ -46,7 +46,7 @@ func Sample(x0, y0, x1, y1, r float64, k int, rnd *rand.Rand) []Point {
 		// make k attempts to place a nearby point
 		for i := 0; i < k; i++ {
 			a := rnd.Float64() * 2 * math.Pi
-			d := rnd.Float64()*r + r
+			d := r * math.Sqrt(rnd.Float64() * 3 + 1)
 			x := point.X + math.Cos(a)*d
 			y := point.Y + math.Sin(a)*d
 			if x < x0 || y < y0 || x > x1 || y > y1 {


### PR DESCRIPTION
Hey Michael, the straightforward approach of using `rnd.Float64()*r + r` to sample from the annulus around the active point unfortunately results in a distribution biased towards the smaller radius.

These two animations give a good illustration of the difference between the techniques: [Annulus Sampling I](https://bl.ocks.org/mbostock/31bd072e50eaf550d79e) (the "naive" approach) and [Annulus Sampling II](https://bl.ocks.org/mbostock/d8b1e0a25467e6034bb9) (the proposed change).

By using `r * math.Sqrt(rnd.Float64() * 3 + 1)` we can generate points uniformly inside the annulus. Note that this is a simplification of `math.Sqrt(rnd.Float64() * (4*r*r - r*r) + r*r)`, which could also be used for clarity.